### PR TITLE
Fix 'make code-generation' error

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 rm -rf ./vendor/k8s.io/code-generator
 go get -d github.com/kubernetes/code-generator/...
-mv /go/src/k8s.io/code-generator ./vendor/k8s.io/
+mv $GOPATH/src/k8s.io/code-generator ./vendor/k8s.io/
 pushd vendor/k8s.io/code-generator
 git checkout kubernetes-1.9.2
 popd


### PR DESCRIPTION
While running `make code-generation` I ran into this error:
```
$ make code-generation 
./hack/update-codegen.sh
mv: cannot stat '/go/src/k8s.io/code-generator': No such file or directory
Makefile:47: recipe for target 'code-generation' failed
make: *** [code-generation] Error 1
```